### PR TITLE
Adding python-dateutil to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ editor>=1.2.1
 PyYAML
 rich
 jira>=3.2.0
+python-dateutil


### PR DESCRIPTION
python-dateutil is needed by decor.py, adding it to requirements.txt.

Signed-off-by: Jason Joyce <jjoyce@redhat.com>