### PR TITLE
Add proxy support, small terminal fixup

### DIFF
--- a/contrib/trolly.json
+++ b/contrib/trolly.json
@@ -1,6 +1,10 @@
 {"jira": {
 	"url": "https://issues.mycompany.com",
 	"token": "f398fjfdsklhn+3879034f783129",
+	"proxies": {
+		"http": "",
+		"https": ""
+	},
 	"default_project": "MYPROJECT",
 	"_comment": "Set to true to enable eval() of code on custom fields. DANGEROUS",
 	"here_there_be_dragons": false,

--- a/trolly/decor.py
+++ b/trolly/decor.py
@@ -4,7 +4,7 @@
 #   http://github.com/release-depot/toolchest
 
 import re
-import os
+import shutil
 
 from dateutil.parser import parse
 from pprint import PrettyPrinter
@@ -142,7 +142,7 @@ def vsep_print(linesplit=None, *vals):
     widths = []
     consumed = 0
 
-    screen_width = os.get_terminal_size()[0]
+    screen_width = shutil.get_terminal_size()[0]
     args = list(vals)
 
     if not args:

--- a/trolly/jira_cli.py
+++ b/trolly/jira_cli.py
@@ -746,8 +746,10 @@ def get_project(project=None):
     if not project:
         # Not sure why I used an array here
         project = jconfig['default_project']
+    if 'proxies' not in jconfig:
+        jconfig['proxies'] = {"http": "", "https": ""}
 
-    jira = JIRA(jconfig['url'], token_auth=jconfig['token'])
+    jira = JIRA(jconfig['url'], token_auth=jconfig['token'], proxies=jconfig['proxies'])
     proj = JiraProject(jira, project, readonly=False, allow_code=allow_code)
     if 'searches' in jconfig:
         proj.set_user_data('searches', jconfig['searches'])


### PR DESCRIPTION
 **Jira: add proxy support**

Some Jira instances may require using a proxy. Enable defining them in
the trolly config and default to no proxy when the entry is missing.

 **Use get_terminal_size from shutil instead of os**

os's get_terminal_size breaks when not calling from a real console,
such as when using an IDE's run configurations.

Also, Python docs[1] say to preferably use shutil.

[1] https://docs.python.org/3/library/os.html#os.get_terminal_size