### PR TITLE
Add two lines for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 High-level CLI for Trello and JIRA
 
 # Installation
-pip install -r requirements.txt .
+pip install -r requirements.txt 
+pip install .
 
 # Notes
 This is not published to pypi because the project name conflicts.


### PR DESCRIPTION
Reason: when reading the README.md file, someone may get confused about this '.' char, not noticing it means the current dir and not just an ordinary period to finish a sentence